### PR TITLE
Fixed: rdn_despeckle -- scale factor should be squared.

### DIFF
--- a/gamera/toolkits/rodan_plugins/plugins/rdn_despeckle.py
+++ b/gamera/toolkits/rodan_plugins/plugins/rdn_despeckle.py
@@ -23,6 +23,7 @@ class rdn_despeckle(PluginFunction):
             scale_factor = 1
         else:
             scale_factor = float(self.ncols) / float(image_width)
+        scale_factor = scale_factor * scale_factor
 
         print "effective cc size = " + str(int(cc_size*scale_factor))
         self.despeckle(int(cc_size*scale_factor))


### PR DESCRIPTION
The argument `cc_size` of Gamera despeckle function stands for the number of connected pixels. Therefore the scaling factor should be `Area(original_image)/Area(thumbnail)`, which is the square of `Width(original_image)/Width(thumbnail)`.
